### PR TITLE
Fix compilation errors

### DIFF
--- a/src/Clothoid.cc
+++ b/src/Clothoid.cc
@@ -1182,7 +1182,7 @@ namespace Clothoid {
 
   static
   inline
-  bool
+  valueType
   power2( valueType a )
   { return a*a ; }
 

--- a/src/Clothoid.hh
+++ b/src/Clothoid.hh
@@ -24,6 +24,7 @@
 #ifndef CLOTHOID_HH
 #define CLOTHOID_HH
 
+#include <iostream>
 #include <vector>
 
 //! Clothoid computations routine


### PR DESCRIPTION
 - Avoid a narrowing conversion by preserving the original return type in power2
 - Add missing include of <iostream> due to usage of std::ostream